### PR TITLE
Fix dialyzer warning

### DIFF
--- a/lib/membrane_ogg/payloader.ex
+++ b/lib/membrane_ogg/payloader.ex
@@ -9,7 +9,7 @@ defmodule Membrane.Ogg.Payloader do
 
   alias __MODULE__.Native
 
-  @spec init(non_neg_integer | :random) :: {:ok, state :: binary} | {:error, reason :: atom}
+  @spec init(non_neg_integer | :random) :: {:ok, state :: reference} | {:error, reason :: atom}
   def init(serial_number) do
     Native.create(stream_identifier(serial_number))
   end


### PR DESCRIPTION
While using this in another project, we are initializing a payloader and
passing the generated reference to the various other functions. Dialyzer
is currently complaining because `Membrane.Ogg.Payloader`'s spec
currently marks its return as `{:ok, binary}` which is causing a spec
mismatch with the other functions which do require a reference.